### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 A Model Context Protocol (MCP) server that enables Claude Desktop (and other MCP clients) to generate images, videos, music, and audio using [Fal.ai](https://fal.ai) models.
 
+<a href="https://glama.ai/mcp/servers/@raveenb/fal-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@raveenb/fal-mcp-server/badge" alt="Fal.ai Server MCP server" />
+</a>
+
 ## ✨ Features
 
 ### 🚀 Performance


### PR DESCRIPTION
This PR adds a badge for the [Fal.ai MCP Server](https://glama.ai/mcp/servers/@raveenb/fal-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@raveenb/fal-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@raveenb/fal-mcp-server/badge" alt="Fal.ai Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.