### PR TITLE
feat: Add uvx support and fix PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         if: steps.check_skip.outputs.skip != 'true'
         run: |
           python -m pip install --upgrade pip
-          pip install python-semantic-release
+          pip install python-semantic-release build twine
 
       - name: Configure Git
         if: steps.check_skip.outputs.skip != 'true'
@@ -82,6 +82,20 @@ jobs:
             echo "new_release=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Build package
+        if: steps.release.outputs.new_release == 'true'
+        run: |
+          python -m build
+          twine check dist/*
+
+      - name: Publish to PyPI
+        if: steps.release.outputs.new_release == 'true'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload dist/*
+
       - name: Release summary
         if: steps.release.outputs.new_release == 'true'
         run: |
@@ -89,6 +103,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Released version: **${{ steps.release.outputs.new_version }}**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "This will trigger:" >> $GITHUB_STEP_SUMMARY
-          echo "- PyPI publish workflow" >> $GITHUB_STEP_SUMMARY
-          echo "- Docker versioned image build" >> $GITHUB_STEP_SUMMARY
+          echo "Published to:" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ GitHub Releases" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ PyPI (uvx/pip installable)" >> $GITHUB_STEP_SUMMARY
+          echo "- 🐳 Docker images (via separate workflow)" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -52,7 +52,36 @@ A Model Context Protocol (MCP) server that enables Claude Desktop (and other MCP
 
 ### Installation
 
-#### Option 1: Docker (Recommended for Production) 🐳
+#### Option 1: uvx (Recommended - Zero Install) ⚡
+
+Run directly without installation using [uv](https://docs.astral.sh/uv/):
+
+```bash
+# Run the MCP server directly
+uvx fal-mcp-server
+
+# Or with specific version
+uvx fal-mcp-server==1.2.0
+```
+
+**Claude Desktop Configuration for uvx:**
+```json
+{
+  "mcpServers": {
+    "fal-ai": {
+      "command": "uvx",
+      "args": ["fal-mcp-server"],
+      "env": {
+        "FAL_KEY": "your-fal-api-key"
+      }
+    }
+  }
+}
+```
+
+> **Note:** Install uv first: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+
+#### Option 2: Docker (Recommended for Production) 🐳
 
 Official Docker image available on GitHub Container Registry:
 
@@ -96,7 +125,7 @@ echo "FAL_KEY=your-api-key" > .env
 docker-compose up -d
 ```
 
-#### Option 2: Install from PyPI
+#### Option 3: Install from PyPI
 
 ```bash
 pip install fal-mcp-server
@@ -107,7 +136,7 @@ Or with uv:
 uv pip install fal-mcp-server
 ```
 
-#### Option 3: Install from source
+#### Option 4: Install from source
 
 ```bash
 git clone https://github.com/raveenb/fal-mcp-server.git


### PR DESCRIPTION
## Summary
Implements uvx (zero-install) support for the MCP server, making it as easy to run as npx-based Node.js MCP servers.

## Changes

### Release Workflow Updates
- Added PyPI publishing directly in `release.yml` (fixes GITHUB_TOKEN limitation)
- The separate `publish.yml` was not triggered when semantic-release created tags
- Now builds and uploads to PyPI in the same workflow

### Documentation Updates
- Added **uvx as Option 1** (recommended) installation method
- Added Claude Desktop configuration example for uvx
- Renumbered existing options (Docker → 2, PyPI → 3, Source → 4)

## Usage After Merge

Once this merges (triggering v1.3.0 release → PyPI publish):

```bash
# Run directly without installation
uvx fal-mcp-server

# Claude Desktop config
{
  "mcpServers": {
    "fal-ai": {
      "command": "uvx",
      "args": ["fal-mcp-server"],
      "env": { "FAL_KEY": "your-key" }
    }
  }
}
```

## Testing
- [ ] CI passes
- [ ] After merge, verify v1.3.0 appears on PyPI
- [ ] Test `uvx fal-mcp-server` works

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)