### PR TITLE
fix: Use PAT for release workflow to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for changelog generation
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT to allow pushing to protected branch
+          # Create a Fine-grained PAT with 'Contents: Read and write' permission
+          # Add it as RELEASE_TOKEN secret in repo settings
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Check for skip-release marker
         id: check_skip
@@ -58,7 +61,7 @@ jobs:
         id: release
         if: steps.check_skip.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           # Run semantic-release to determine if a release is needed
           # This parses commit messages following Conventional Commits:


### PR DESCRIPTION
## Summary
- Updates release workflow to use `RELEASE_TOKEN` (PAT) instead of `GITHUB_TOKEN`
- Allows semantic-release to push version commits to the protected main branch
- Fixes the release workflow failure after PR #24 was merged

## Setup Required
To use this fix, you need to create a Personal Access Token (PAT) and add it as a repository secret:

### 1. Create a Fine-grained PAT
1. Go to [GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens](https://github.com/settings/tokens?type=beta)
2. Click "Generate new token"
3. **Token name**: `fal-mcp-release-token`
4. **Repository access**: Select "Only select repositories" → Choose `fal-mcp-server`
5. **Permissions**:
   - **Repository permissions**:
     - Contents: **Read and write** (to push version commits)
     - Metadata: **Read-only** (required)
6. Click "Generate token" and copy the token

### 2. Add as Repository Secret
1. Go to your repository → Settings → Secrets and variables → Actions
2. Click "New repository secret"
3. **Name**: `RELEASE_TOKEN`
4. **Secret**: Paste your PAT
5. Click "Add secret"

## Why a PAT is needed
The default `GITHUB_TOKEN` cannot push to protected branches. By using a PAT with "Contents: Read and write" permission, semantic-release can bypass branch protection rules to push version bump commits directly to main.

## Test plan
- [ ] Create PAT with required permissions
- [ ] Add `RELEASE_TOKEN` secret to repository
- [ ] Merge this PR
- [ ] Trigger release workflow (should succeed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)