### PR TITLE
chore: Add Dependabot for automated dependency and security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+# Dependabot configuration for automated dependency updates and security alerts
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Python dependencies (pip)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+    # Group minor and patch updates to reduce PR noise
+    groups:
+      dev-dependencies:
+        patterns:
+          - "pytest*"
+          - "black"
+          - "ruff"
+          - "mypy"
+          - "types-*"
+        update-types:
+          - "minor"
+          - "patch"
+      runtime-dependencies:
+        patterns:
+          - "mcp"
+          - "fal-client"
+          - "starlette"
+          - "uvicorn"
+          - "sse-starlette"
+          - "loguru"
+        update-types:
+          - "patch"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Docker base images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary
Adds Dependabot configuration for automated dependency monitoring and security vulnerability alerts.

## What this enables

### 1. Automated Dependency Updates
| Ecosystem | Frequency | Grouping |
|-----------|-----------|----------|
| Python (pip) | Weekly (Monday) | Dev deps grouped, runtime deps grouped |
| GitHub Actions | Weekly (Monday) | All grouped |
| Docker | Weekly (Monday) | - |

### 2. Security Vulnerability Alerts
- **Automatic**: GitHub enables security alerts when Dependabot is configured
- **Immediate PRs**: Critical vulnerabilities trigger PRs immediately (not waiting for schedule)
- **CVE tracking**: Alerts include CVE details and severity

### 3. Grouped Updates
To reduce PR noise, updates are grouped:
- `dev-dependencies`: pytest, black, ruff, mypy, etc.
- `runtime-dependencies`: mcp, fal-client, starlette, etc. (patch only)
- `github-actions`: All action updates

## What about fal.ai changelog?
Our dynamic model discovery (PR #17) automatically picks up new models. For API changes:
- Check [fal.ai changelog](https://docs.fal.ai/changelog) monthly
- Create issues for breaking changes or new capabilities

## Test plan
- [ ] Merge PR
- [ ] Verify Dependabot shows in repo Settings → Code security
- [ ] Wait for first weekly run (or manually trigger via Security tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)