### PR TITLE
fix: Repair GitHub Pages styling and visibility

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,13 +1,13 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 4.3.0"
+gem "jekyll", "~> 4.3"
 gem "minima", "~> 2.5"
+gem "webrick", "~> 1.8"  # Required for Ruby 3.x
 
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-sitemap"
   gem "jekyll-seo-tag"
-  gem "jekyll-redirect-from"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,7 +23,6 @@ plugins:
   - jekyll-feed
   - jekyll-sitemap
   - jekyll-seo-tag
-  - jekyll-redirect-from
 
 # Analytics
 google_analytics: # Add your GA4 ID here
@@ -60,17 +59,7 @@ defaults:
       path: ""
       type: "pages"
     values:
-      layout: "default"
-  - scope:
-      path: "api"
-      type: "pages"
-    values:
-      layout: "api"
-  - scope:
-      path: "examples"
-      type: "pages"
-    values:
-      layout: "example"
+      layout: "page"
 
 # Exclude from build
 exclude:

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,7 +1,7 @@
 ---
 ---
 
-@import "{{ site.theme }}";
+@import "minima";
 
 // Custom styles for Fal MCP Server docs
 


### PR DESCRIPTION
## Summary

Fixes the GitHub Pages site layout/styling issues and adds the site to the repo's About section.

## Changes

### Jekyll Configuration Fixes
- **SCSS import**: Changed `@import "{{ site.theme }}"` to `@import "minima"` - the Liquid variable wasn't resolving correctly
- **Added webrick**: Required for Ruby 3.x local development
- **Removed unused plugin**: `jekyll-redirect-from` was listed but not needed
- **Fixed layout defaults**: Simplified to use minima's built-in `page` layout instead of non-existent custom layouts

### Repo Settings
- **Homepage URL**: Set to `https://raveenb.github.io/fal-mcp-server/` so it appears in the repo's About section

## Test Plan

- [ ] CI passes (Pages workflow builds successfully)
- [ ] Site renders correctly at https://raveenb.github.io/fal-mcp-server/
- [ ] CSS/styling loads properly
- [ ] Website link visible in repo About section

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)