### PR TITLE
feat(docs): Add custom header with modern navigation design

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,0 +1,34 @@
+<header class="site-header-custom">
+  <div class="header-container">
+    <a class="site-logo" href="{{ '/' | relative_url }}">
+      <span class="logo-icon">&#9670;</span>
+      <span class="logo-text">{{ site.title | escape }}</span>
+    </a>
+
+    <button class="nav-toggle" aria-label="Toggle navigation">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+
+    <nav class="site-nav-custom">
+      <a href="{{ '/installation' | relative_url }}">Install</a>
+      <a href="{{ '/api' | relative_url }}">API</a>
+      <a href="{{ '/examples' | relative_url }}">Examples</a>
+      <a href="{{ '/docker' | relative_url }}">Docker</a>
+      <a href="https://github.com/raveenb/fal-mcp-server" class="nav-github" target="_blank" rel="noopener">
+        <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
+    </nav>
+  </div>
+</header>
+
+<script>
+document.querySelector('.nav-toggle').addEventListener('click', function() {
+  document.querySelector('.site-nav-custom').classList.toggle('nav-open');
+  this.classList.toggle('active');
+});
+</script>

--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -3,6 +3,167 @@
 
 @import "minima";
 
+// ============================================
+// Custom Header Styles
+// ============================================
+
+.site-header-custom {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 0;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.header-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 60px;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: white;
+  font-weight: 700;
+  font-size: 1.2em;
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 0.9;
+    text-decoration: none;
+  }
+
+  .logo-icon {
+    font-size: 1.5em;
+    line-height: 1;
+  }
+
+  .logo-text {
+    letter-spacing: -0.5px;
+  }
+}
+
+.site-nav-custom {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  a {
+    color: rgba(255, 255, 255, 0.9);
+    text-decoration: none;
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-size: 0.95em;
+    font-weight: 500;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.15);
+      color: white;
+      text-decoration: none;
+    }
+  }
+
+  .nav-github {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+
+    svg {
+      width: 18px;
+      height: 18px;
+    }
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.2);
+      border-color: rgba(255, 255, 255, 0.3);
+    }
+  }
+}
+
+// Mobile hamburger button
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 10px;
+  z-index: 1001;
+
+  span {
+    display: block;
+    width: 24px;
+    height: 2px;
+    background: white;
+    border-radius: 2px;
+    transition: all 0.3s ease;
+  }
+
+  &.active {
+    span:nth-child(1) {
+      transform: rotate(45deg) translate(5px, 5px);
+    }
+    span:nth-child(2) {
+      opacity: 0;
+    }
+    span:nth-child(3) {
+      transform: rotate(-45deg) translate(5px, -5px);
+    }
+  }
+}
+
+// Mobile responsive header
+@media (max-width: 768px) {
+  .nav-toggle {
+    display: flex;
+  }
+
+  .site-nav-custom {
+    position: fixed;
+    top: 60px;
+    left: 0;
+    right: 0;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    flex-direction: column;
+    padding: 20px;
+    gap: 5px;
+    transform: translateY(-100%);
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+
+    &.nav-open {
+      transform: translateY(0);
+      opacity: 1;
+      visibility: visible;
+    }
+
+    a {
+      width: 100%;
+      text-align: center;
+      padding: 12px 20px;
+    }
+
+    .nav-github span {
+      display: inline;
+    }
+  }
+}
+
 // Custom styles for Fal MCP Server docs
 
 // Hero section


### PR DESCRIPTION
## Summary

- Create custom `header.html` override for minima theme with a clean, modern navigation
- Add responsive navigation with mobile hamburger menu (slide-down animation)
- Style header with purple/blue gradient (`#667eea` → `#764ba2`) matching the hero section
- Include GitHub link with inline SVG icon
- Add smooth hover transitions and mobile-first responsive design

## Changes

| File | Description |
|------|-------------|
| `docs/_includes/header.html` | New custom header with logo, nav links, and mobile toggle |
| `docs/assets/main.scss` | Header styles with flexbox layout and responsive breakpoints |

## Visual Preview

The new header features:
- **Logo**: Diamond icon + "Fal MCP Server" text on the left
- **Navigation**: Install, API, Examples, Docker, GitHub (with icon) on the right
- **Mobile**: Hamburger menu that transforms to X, slide-down nav panel
- **Styling**: Sticky header, gradient background, subtle shadow, hover states

## Test plan

- [ ] Verify header renders correctly on desktop
- [ ] Test mobile hamburger menu toggle functionality
- [ ] Check navigation links work correctly
- [ ] Verify GitHub link opens in new tab
- [ ] Test sticky behavior on scroll

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)