### PR TITLE
fix(docs): Use correct Rouge class names for code block styling

### DIFF
--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -376,19 +376,28 @@ pre code {
   overflow: hidden;
   margin: 1.5em 0;
 
+  // Reset pre styles inside highlight
   pre {
     margin: 0;
     padding: 0;
     background: transparent;
+    border-radius: 0;
   }
 
-  // Table structure for line numbers
-  table {
+  // Main pre.highlight wrapper
+  > pre.highlight {
+    padding: 0;
+    margin: 0;
+  }
+
+  // Rouge table structure for line numbers
+  .rouge-table {
     width: 100%;
     border-collapse: collapse;
     border: none;
     margin: 0;
     padding: 0;
+    border-spacing: 0;
 
     td {
       padding: 0;
@@ -396,38 +405,43 @@ pre code {
       vertical-align: top;
     }
 
-    // Line numbers column
-    td.gutter,
-    td.gl {
+    // Line numbers gutter
+    .rouge-gutter {
       width: 50px;
-      padding: 15px 10px 15px 15px;
+      padding: 15px 12px 15px 15px;
       color: #636d83;
       text-align: right;
       user-select: none;
       border-right: 1px solid #3e4451;
+      background: rgba(0, 0, 0, 0.1);
 
-      pre {
+      pre.lineno {
         color: #636d83;
         padding: 0;
         margin: 0;
         background: transparent;
+        white-space: pre;
+        line-height: 1.5;
       }
     }
 
     // Code content column
-    td.code {
+    .rouge-code {
       padding: 15px;
+      overflow-x: auto;
 
       pre {
         padding: 0;
         margin: 0;
+        white-space: pre;
+        line-height: 1.5;
         overflow-x: auto;
       }
     }
   }
 
   // Fallback for code blocks without table structure
-  > pre {
+  > pre:not(.highlight) {
     padding: 15px;
   }
 }


### PR DESCRIPTION
## Summary

Follow-up fix to PR #38 - uses correct Rouge syntax highlighter class names.

## Problem

The previous CSS was targeting generic class names (`td.gutter`, `td.code`) but Rouge generates specific class names:
- `.rouge-table`
- `.rouge-gutter` (not `.gutter`)
- `.rouge-code` (not `.code`)

## Changes

- Updated CSS selectors to target actual Rouge classes
- Added `white-space: pre` to preserve line breaks in code
- Added subtle darker background to line number gutter
- Set consistent `line-height: 1.5` for alignment

## Test plan

- [ ] Verify code blocks display with line numbers on left
- [ ] Verify code content preserves line breaks
- [ ] Check horizontal scrolling for long lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)