### PR TITLE
fix(docs): Use correct Rouge class names for code block styling

### DIFF
--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -380,15 +380,18 @@ pre code {
     margin: 0;
     padding: 0;
     background: transparent;
+    border-radius: 0;
   }
 
-  // Table structure for line numbers
+  // Rouge table structure (.rouge-table is the actual class name)
+  .rouge-table,
   table {
     width: 100%;
     border-collapse: collapse;
     border: none;
     margin: 0;
     padding: 0;
+    border-spacing: 0;
 
     td {
       padding: 0;
@@ -396,31 +399,40 @@ pre code {
       vertical-align: top;
     }
 
-    // Line numbers column
+    // Line numbers gutter (.rouge-gutter is the actual class name)
+    .rouge-gutter,
     td.gutter,
     td.gl {
       width: 50px;
-      padding: 15px 10px 15px 15px;
+      padding: 15px 12px 15px 15px;
       color: #636d83;
       text-align: right;
       user-select: none;
       border-right: 1px solid #3e4451;
+      background: rgba(0, 0, 0, 0.15);
 
-      pre {
+      pre,
+      pre.lineno {
         color: #636d83;
         padding: 0;
         margin: 0;
         background: transparent;
+        white-space: pre;
+        line-height: 1.6;
       }
     }
 
-    // Code content column
+    // Code content column (.rouge-code is the actual class name)
+    .rouge-code,
     td.code {
       padding: 15px;
+      overflow-x: auto;
 
       pre {
         padding: 0;
         margin: 0;
+        white-space: pre;
+        line-height: 1.6;
         overflow-x: auto;
       }
     }
@@ -429,6 +441,8 @@ pre code {
   // Fallback for code blocks without table structure
   > pre {
     padding: 15px;
+    white-space: pre;
+    line-height: 1.6;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes code block rendering by targeting the correct Rouge syntax highlighter class names.

## Problem

Code blocks with line numbers weren't displaying correctly because the CSS was targeting generic class names, but Rouge generates specific class names:
- `.rouge-table` (not just `table`)
- `.rouge-gutter` (not `td.gutter` or `td.gl`)
- `.rouge-code` (not `td.code`)

## Solution

Updated CSS selectors to target both Rouge-specific and generic fallback classes:
- Added `.rouge-table`, `.rouge-gutter`, `.rouge-code` selectors
- Added `white-space: pre` to preserve line breaks
- Added `line-height: 1.6` for consistent spacing
- Added subtle darker background to line number gutter

## Test plan

- [ ] Verify code blocks display with line numbers on left column
- [ ] Verify code content preserves line breaks
- [ ] Check horizontal scrolling for long lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)