### PR TITLE
feat(image): Add enable_safety_checker and output_format parameters

### DIFF
--- a/src/fal_mcp_server/server.py
+++ b/src/fal_mcp_server/server.py
@@ -126,6 +126,17 @@ async def list_tools() -> List[Tool]:
                         "type": "integer",
                         "description": "Seed for reproducible generation",
                     },
+                    "enable_safety_checker": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Enable safety checker to filter inappropriate content",
+                    },
+                    "output_format": {
+                        "type": "string",
+                        "enum": ["jpeg", "png", "webp"],
+                        "default": "png",
+                        "description": "Output image format",
+                    },
                 },
                 "required": ["prompt"],
             },
@@ -250,6 +261,10 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
                 fal_args["negative_prompt"] = arguments["negative_prompt"]
             if "seed" in arguments:
                 fal_args["seed"] = arguments["seed"]
+            if "enable_safety_checker" in arguments:
+                fal_args["enable_safety_checker"] = arguments["enable_safety_checker"]
+            if "output_format" in arguments:
+                fal_args["output_format"] = arguments["output_format"]
 
             # Use native async API for fast image generation
             result = await fal_client.run_async(model_id, arguments=fal_args)


### PR DESCRIPTION
## Summary

- Adds `enable_safety_checker` parameter (boolean, default: true) to toggle content safety filtering
- Adds `output_format` parameter (enum: jpeg, png, webp; default: png) to control output image format

These parameters match what fal.ai's portal provides when generating images, giving users more control over their generated content.

## Changes

- Updated `generate_image` tool schema with new parameters
- Updated `call_tool` function to pass new parameters to fal.ai API

## Test plan

- [x] All existing tests pass (25 tests)
- [x] Ruff linting passes
- [ ] Manual test: Generate image with `enable_safety_checker: false`
- [ ] Manual test: Generate image with `output_format: "webp"`

## Related

Partial fix for #49 - Additional parameters (guidance_scale, num_inference_steps, etc.) may be added in future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)