### PR TITLE
fix: Add prompt parameter to generate_video and update default model

### DIFF
--- a/src/fal_mcp_server/server.py
+++ b/src/fal_mcp_server/server.py
@@ -321,6 +321,20 @@ async def list_tools() -> List[Tool]:
                         "maximum": 10,
                         "description": "Video duration in seconds",
                     },
+                    "aspect_ratio": {
+                        "type": "string",
+                        "default": "16:9",
+                        "description": "Video aspect ratio (e.g., '16:9', '9:16', '1:1')",
+                    },
+                    "negative_prompt": {
+                        "type": "string",
+                        "description": "What to avoid in the video (e.g., 'blur, distort, low quality')",
+                    },
+                    "cfg_scale": {
+                        "type": "number",
+                        "default": 0.5,
+                        "description": "Classifier-free guidance scale (0.0-1.0). Lower values give more creative results.",
+                    },
                 },
                 "required": ["image_url", "prompt"],
             },
@@ -783,6 +797,12 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
             }
             if "duration" in arguments:
                 fal_args["duration"] = arguments["duration"]
+            if "aspect_ratio" in arguments:
+                fal_args["aspect_ratio"] = arguments["aspect_ratio"]
+            if "negative_prompt" in arguments:
+                fal_args["negative_prompt"] = arguments["negative_prompt"]
+            if "cfg_scale" in arguments:
+                fal_args["cfg_scale"] = arguments["cfg_scale"]
 
             # Use subscribe_async with timeout protection
             logger.info("Starting video generation with %s", model_id)

--- a/src/fal_mcp_server/server_dual.py
+++ b/src/fal_mcp_server/server_dual.py
@@ -147,6 +147,20 @@ class FalMCPServer:
                                 "maximum": 10,
                                 "description": "Video duration in seconds",
                             },
+                            "aspect_ratio": {
+                                "type": "string",
+                                "default": "16:9",
+                                "description": "Video aspect ratio (e.g., '16:9', '9:16', '1:1')",
+                            },
+                            "negative_prompt": {
+                                "type": "string",
+                                "description": "What to avoid in the video (e.g., 'blur, distort, low quality')",
+                            },
+                            "cfg_scale": {
+                                "type": "number",
+                                "default": 0.5,
+                                "description": "Classifier-free guidance scale (0.0-1.0). Lower values give more creative results.",
+                            },
                         },
                         "required": ["image_url", "prompt"],
                     },
@@ -260,7 +274,7 @@ class FalMCPServer:
 
                 # Long operations using queue API
                 elif name == "generate_video":
-                    model_input = arguments.get("model", "svd")
+                    model_input = arguments.get("model", "fal-ai/wan-i2v")
                     try:
                         model_id = await registry.resolve_model_id(model_input)
                     except ValueError as e:
@@ -271,9 +285,18 @@ class FalMCPServer:
                             )
                         ]
 
-                    fal_args = {"image_url": arguments["image_url"]}
+                    fal_args = {
+                        "image_url": arguments["image_url"],
+                        "prompt": arguments["prompt"],
+                    }
                     if "duration" in arguments:
                         fal_args["duration"] = arguments["duration"]
+                    if "aspect_ratio" in arguments:
+                        fal_args["aspect_ratio"] = arguments["aspect_ratio"]
+                    if "negative_prompt" in arguments:
+                        fal_args["negative_prompt"] = arguments["negative_prompt"]
+                    if "cfg_scale" in arguments:
+                        fal_args["cfg_scale"] = arguments["cfg_scale"]
 
                     # Submit to queue for processing
                     handle = await fal_client.submit_async(model_id, arguments=fal_args)

--- a/src/fal_mcp_server/server_http.py
+++ b/src/fal_mcp_server/server_http.py
@@ -168,6 +168,20 @@ async def list_tools() -> List[Tool]:
                         "maximum": 10,
                         "description": "Video duration in seconds",
                     },
+                    "aspect_ratio": {
+                        "type": "string",
+                        "default": "16:9",
+                        "description": "Video aspect ratio (e.g., '16:9', '9:16', '1:1')",
+                    },
+                    "negative_prompt": {
+                        "type": "string",
+                        "description": "What to avoid in the video (e.g., 'blur, distort, low quality')",
+                    },
+                    "cfg_scale": {
+                        "type": "number",
+                        "default": 0.5,
+                        "description": "Classifier-free guidance scale (0.0-1.0). Lower values give more creative results.",
+                    },
                 },
                 "required": ["image_url", "prompt"],
             },
@@ -297,6 +311,12 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
             }
             if "duration" in arguments:
                 fal_args["duration"] = arguments["duration"]
+            if "aspect_ratio" in arguments:
+                fal_args["aspect_ratio"] = arguments["aspect_ratio"]
+            if "negative_prompt" in arguments:
+                fal_args["negative_prompt"] = arguments["negative_prompt"]
+            if "cfg_scale" in arguments:
+                fal_args["cfg_scale"] = arguments["cfg_scale"]
 
             # Submit to queue for processing
             handle = await fal_client.submit_async(model_id, arguments=fal_args)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -185,6 +185,17 @@ async def test_generate_video_tool_schema():
     assert props["duration"]["minimum"] == 2
     assert props["duration"]["maximum"] == 10
 
+    # Check additional optional parameters
+    assert "aspect_ratio" in props
+    assert props["aspect_ratio"]["default"] == "16:9"
+
+    assert "negative_prompt" in props
+    assert props["negative_prompt"]["type"] == "string"
+
+    assert "cfg_scale" in props
+    assert props["cfg_scale"]["type"] == "number"
+    assert props["cfg_scale"]["default"] == 0.5
+
     # Both image_url and prompt are required
     assert "image_url" in video_tool.inputSchema["required"]
     assert "prompt" in video_tool.inputSchema["required"]


### PR DESCRIPTION
## Summary

- Adds required `prompt` parameter to `generate_video` tool for guiding video animation
- Changes default model from deprecated `svd` to `fal-ai/wan-i2v` (Wan 2.1)
- Adds optional parameters: `aspect_ratio`, `negative_prompt`, `cfg_scale`
- Updates all server variants (server.py, server_http.py, server_dual.py)
- Adds comprehensive test for generate_video tool schema

## Problem

The `generate_video` tool was completely broken:
1. Default model `svd` (Stable Video Diffusion) no longer exists on Fal.ai
2. All current video models require a `prompt` field to guide animation

## Solution

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `image_url` | string | **required** | Starting image URL |
| `prompt` | string | **required** | Text to guide animation |
| `model` | string | `fal-ai/wan-i2v` | Video model to use |
| `duration` | integer | 5 | Duration in seconds (2-10) |
| `aspect_ratio` | string | `16:9` | Video aspect ratio |
| `negative_prompt` | string | - | What to avoid |
| `cfg_scale` | number | 0.5 | Guidance scale (0.0-1.0) |

## Example Usage

```json
{
  "image_url": "https://example.com/image.jpg",
  "prompt": "A slow-motion drone shot with gentle camera movement",
  "duration": 5,
  "aspect_ratio": "16:9",
  "negative_prompt": "blur, distort, low quality",
  "cfg_scale": 0.5
}
```

## Test plan

- [x] All existing tests pass (10/10)
- [x] New `test_generate_video_tool_schema` test validates all parameters
- [x] Ruff linting passes
- [x] Critical bug in server_dual.py fixed (caught by PR review)
- [ ] Manual testing with actual video generation (requires release)

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)