### PR TITLE
fix: Make image_url optional in generate_video for text-to-video support

### DIFF
--- a/src/fal_mcp_server/server.py
+++ b/src/fal_mcp_server/server.py
@@ -297,22 +297,22 @@ async def list_tools() -> List[Tool]:
         ),
         Tool(
             name="generate_video",
-            description="Generate videos from images. Use list_models with category='video' to discover available models.",
+            description="Generate videos from text prompts (text-to-video) or from images (image-to-video). Use list_models with category='video' to discover available models.",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "image_url": {
-                        "type": "string",
-                        "description": "Starting image URL (for image-to-video)",
-                    },
                     "prompt": {
                         "type": "string",
-                        "description": "Text description to guide the video animation (e.g., 'camera slowly pans right, gentle breeze moves the leaves')",
+                        "description": "Text description for the video (e.g., 'A slow-motion drone shot of Tokyo at night')",
+                    },
+                    "image_url": {
+                        "type": "string",
+                        "description": "Starting image URL for image-to-video models. Optional for text-to-video models.",
                     },
                     "model": {
                         "type": "string",
                         "default": "fal-ai/wan-i2v",
-                        "description": "Model ID (e.g., 'fal-ai/kling-video/v2.1/standard/image-to-video'). Use list_models to see options.",
+                        "description": "Model ID. Use 'fal-ai/kling-video/v2/master/text-to-video' for text-only, or image-to-video models like 'fal-ai/wan-i2v'.",
                     },
                     "duration": {
                         "type": "integer",
@@ -336,7 +336,7 @@ async def list_tools() -> List[Tool]:
                         "description": "Classifier-free guidance scale (0.0-1.0). Lower values give more creative results.",
                     },
                 },
-                "required": ["image_url", "prompt"],
+                "required": ["prompt"],
             },
         ),
         Tool(
@@ -792,9 +792,11 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
                 ]
 
             fal_args = {
-                "image_url": arguments["image_url"],
                 "prompt": arguments["prompt"],
             }
+            # image_url is optional - only needed for image-to-video models
+            if "image_url" in arguments:
+                fal_args["image_url"] = arguments["image_url"]
             if "duration" in arguments:
                 fal_args["duration"] = arguments["duration"]
             if "aspect_ratio" in arguments:

--- a/src/fal_mcp_server/server_dual.py
+++ b/src/fal_mcp_server/server_dual.py
@@ -123,22 +123,22 @@ class FalMCPServer:
                 ),
                 Tool(
                     name="generate_video",
-                    description="Generate videos from images. Use list_models with category='video' to discover available models.",
+                    description="Generate videos from text prompts (text-to-video) or from images (image-to-video). Use list_models with category='video' to discover available models.",
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "image_url": {
-                                "type": "string",
-                                "description": "Starting image URL (for image-to-video)",
-                            },
                             "prompt": {
                                 "type": "string",
-                                "description": "Text description to guide the video animation (e.g., 'camera slowly pans right, gentle breeze moves the leaves')",
+                                "description": "Text description for the video (e.g., 'A slow-motion drone shot of Tokyo at night')",
+                            },
+                            "image_url": {
+                                "type": "string",
+                                "description": "Starting image URL for image-to-video models. Optional for text-to-video models.",
                             },
                             "model": {
                                 "type": "string",
                                 "default": "fal-ai/wan-i2v",
-                                "description": "Model ID (e.g., 'fal-ai/kling-video/v2.1/standard/image-to-video'). Use list_models to see options.",
+                                "description": "Model ID. Use 'fal-ai/kling-video/v2/master/text-to-video' for text-only, or image-to-video models like 'fal-ai/wan-i2v'.",
                             },
                             "duration": {
                                 "type": "integer",
@@ -162,7 +162,7 @@ class FalMCPServer:
                                 "description": "Classifier-free guidance scale (0.0-1.0). Lower values give more creative results.",
                             },
                         },
-                        "required": ["image_url", "prompt"],
+                        "required": ["prompt"],
                     },
                 ),
                 Tool(
@@ -286,9 +286,11 @@ class FalMCPServer:
                         ]
 
                     fal_args = {
-                        "image_url": arguments["image_url"],
                         "prompt": arguments["prompt"],
                     }
+                    # image_url is optional - only needed for image-to-video models
+                    if "image_url" in arguments:
+                        fal_args["image_url"] = arguments["image_url"]
                     if "duration" in arguments:
                         fal_args["duration"] = arguments["duration"]
                     if "aspect_ratio" in arguments:

--- a/src/fal_mcp_server/server_http.py
+++ b/src/fal_mcp_server/server_http.py
@@ -144,22 +144,22 @@ async def list_tools() -> List[Tool]:
         ),
         Tool(
             name="generate_video",
-            description="Generate videos from images. Use list_models with category='video' to discover available models.",
+            description="Generate videos from text prompts (text-to-video) or from images (image-to-video). Use list_models with category='video' to discover available models.",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "image_url": {
-                        "type": "string",
-                        "description": "Starting image URL (for image-to-video)",
-                    },
                     "prompt": {
                         "type": "string",
-                        "description": "Text description to guide the video animation (e.g., 'camera slowly pans right, gentle breeze moves the leaves')",
+                        "description": "Text description for the video (e.g., 'A slow-motion drone shot of Tokyo at night')",
+                    },
+                    "image_url": {
+                        "type": "string",
+                        "description": "Starting image URL for image-to-video models. Optional for text-to-video models.",
                     },
                     "model": {
                         "type": "string",
                         "default": "fal-ai/wan-i2v",
-                        "description": "Model ID (e.g., 'fal-ai/kling-video/v2.1/standard/image-to-video'). Use list_models to see options.",
+                        "description": "Model ID. Use 'fal-ai/kling-video/v2/master/text-to-video' for text-only, or image-to-video models like 'fal-ai/wan-i2v'.",
                     },
                     "duration": {
                         "type": "integer",
@@ -183,7 +183,7 @@ async def list_tools() -> List[Tool]:
                         "description": "Classifier-free guidance scale (0.0-1.0). Lower values give more creative results.",
                     },
                 },
-                "required": ["image_url", "prompt"],
+                "required": ["prompt"],
             },
         ),
         Tool(
@@ -306,9 +306,11 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
                 ]
 
             fal_args = {
-                "image_url": arguments["image_url"],
                 "prompt": arguments["prompt"],
             }
+            # image_url is optional - only needed for image-to-video models
+            if "image_url" in arguments:
+                fal_args["image_url"] = arguments["image_url"]
             if "duration" in arguments:
                 fal_args["duration"] = arguments["duration"]
             if "aspect_ratio" in arguments:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -160,7 +160,7 @@ async def test_generate_image_structured_tool_schema():
 
 @pytest.mark.asyncio
 async def test_generate_video_tool_schema():
-    """Test that generate_video tool has correct schema with prompt parameter"""
+    """Test that generate_video tool has correct schema supporting both text-to-video and image-to-video"""
     from fal_mcp_server.server import list_tools
 
     tools = await list_tools()
@@ -169,12 +169,13 @@ async def test_generate_video_tool_schema():
     assert video_tool is not None
     props = video_tool.inputSchema["properties"]
 
-    # Check required fields
-    assert "image_url" in props
-    assert props["image_url"]["type"] == "string"
-
+    # Check prompt (required for all video generation)
     assert "prompt" in props
     assert props["prompt"]["type"] == "string"
+
+    # Check image_url (optional - only for image-to-video models)
+    assert "image_url" in props
+    assert props["image_url"]["type"] == "string"
 
     # Check optional fields
     assert "model" in props
@@ -196,9 +197,9 @@ async def test_generate_video_tool_schema():
     assert props["cfg_scale"]["type"] == "number"
     assert props["cfg_scale"]["default"] == 0.5
 
-    # Both image_url and prompt are required
-    assert "image_url" in video_tool.inputSchema["required"]
-    assert "prompt" in video_tool.inputSchema["required"]
+    # Only prompt is required (image_url is optional for text-to-video)
+    assert video_tool.inputSchema["required"] == ["prompt"]
+    assert "image_url" not in video_tool.inputSchema["required"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Makes `image_url` optional in the `generate_video` tool to support text-to-video models.

## Problem

The tool incorrectly required `image_url`, but text-to-video models like `fal-ai/kling-video/v2/master/text-to-video` only need a `prompt`.

## Changes

| Before | After |
|--------|-------|
| `required: ["image_url", "prompt"]` | `required: ["prompt"]` |
| Handler always included `image_url` | Handler conditionally includes `image_url` |

## Video Workflows Now Supported

**Text-to-Video** (no image needed):
```json
{
  "prompt": "A slow-motion drone shot of Tokyo at night",
  "model": "fal-ai/kling-video/v2/master/text-to-video"
}
```

**Image-to-Video** (image + prompt):
```json
{
  "prompt": "Camera slowly pans across the scene",
  "image_url": "https://example.com/image.jpg",
  "model": "fal-ai/wan-i2v"
}
```

## Test plan

- [x] All tests pass (10/10)
- [x] Ruff linting passes
- [x] Updated test validates `required == ["prompt"]`

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)