### PR TITLE
feat: Add upload_file tool for uploading local files (#64)

### DIFF
--- a/src/fal_mcp_server/server_dual.py
+++ b/src/fal_mcp_server/server_dual.py
@@ -201,10 +201,6 @@ class FalMCPServer:
                                 "type": "string",
                                 "description": "Absolute path to the local file to upload (e.g., '/path/to/image.png')",
                             },
-                            "content_type": {
-                                "type": "string",
-                                "description": "Optional MIME type of the file (e.g., 'image/png', 'video/mp4'). Auto-detected if not specified.",
-                            },
                         },
                         "required": ["file_path"],
                     },
@@ -419,21 +415,24 @@ class FalMCPServer:
                             )
                         ]
 
-                    # Get file size for logging
-                    file_size = os.path.getsize(file_path)
-                    file_size_mb = file_size / (1024 * 1024)
-                    logger.info("Uploading file: %s (%.2f MB)", file_path, file_size_mb)
-
                     try:
+                        # Get file size for logging (inside try to handle race conditions)
+                        file_size = os.path.getsize(file_path)
+                        file_size_mb = file_size / (1024 * 1024)
+                        logger.info(
+                            "Uploading file: %s (%.2f MB)", file_path, file_size_mb
+                        )
+
                         # Upload file to Fal.ai storage
                         # fal_client.upload_file is synchronous, run in thread pool
-                        loop = asyncio.get_event_loop()
+                        loop = asyncio.get_running_loop()
                         url = await loop.run_in_executor(
                             None, fal_client.upload_file, file_path
                         )
 
                         # Get filename for display
                         filename = os.path.basename(file_path)
+                        logger.info("Successfully uploaded %s to %s", file_path, url)
 
                         return [
                             TextContent(
@@ -441,8 +440,18 @@ class FalMCPServer:
                                 text=f"📤 Uploaded `{filename}` ({file_size_mb:.2f} MB)\n\n**URL:** {url}\n\nThis URL can now be used with other Fal.ai tools.",
                             )
                         ]
+                    except OSError as e:
+                        logger.error("Cannot access file %s: %s", file_path, e)
+                        return [
+                            TextContent(
+                                type="text",
+                                text=f"❌ Cannot access file: {file_path}. {str(e)}",
+                            )
+                        ]
                     except Exception as upload_error:
-                        logger.exception("File upload failed: %s", upload_error)
+                        logger.exception(
+                            "Unexpected error during file upload: %s", upload_error
+                        )
                         return [
                             TextContent(
                                 type="text",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -218,10 +218,6 @@ async def test_upload_file_tool_schema():
     assert "file_path" in props
     assert props["file_path"]["type"] == "string"
 
-    # Check optional content_type parameter
-    assert "content_type" in props
-    assert props["content_type"]["type"] == "string"
-
     # Only file_path is required
     assert upload_tool.inputSchema["required"] == ["file_path"]
 


### PR DESCRIPTION
## Summary

- Adds `upload_file` tool to upload local files (images, videos, audio) to Fal.ai storage
- Returns a URL that can be used with other Fal.ai tools (e.g., image-to-video, audio transform)
- Validates file exists and reports file size in response
- Updated all server variants (server.py, server_http.py, server_dual.py)
- Added test for tool schema

## Test plan

- [x] Unit tests pass (`pytest tests/test_server.py`)
- [x] Linting passes (`ruff check`)
- [x] Formatting passes (`black`)
- [ ] Manual testing with actual file upload

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)