### PR TITLE
feat: async video submission with multi-shot support (submit_video + check_video_status)

### DIFF
--- a/src/fal_mcp_server/handlers/__init__.py
+++ b/src/fal_mcp_server/handlers/__init__.py
@@ -28,9 +28,11 @@ from fal_mcp_server.handlers.utility_handlers import (
     handle_upload_file,
 )
 from fal_mcp_server.handlers.video_handlers import (
+    handle_check_video_status,
     handle_generate_video,
     handle_generate_video_from_image,
     handle_generate_video_from_video,
+    handle_submit_video,
 )
 
 __all__ = [
@@ -55,6 +57,8 @@ __all__ = [
     "handle_generate_video",
     "handle_generate_video_from_image",
     "handle_generate_video_from_video",
+    "handle_submit_video",
+    "handle_check_video_status",
     # Audio handlers
     "handle_generate_music",
 ]

--- a/src/fal_mcp_server/handlers/video_handlers.py
+++ b/src/fal_mcp_server/handlers/video_handlers.py
@@ -419,6 +419,10 @@ async def handle_submit_video(
     if "cfg_scale" in arguments:
         fal_args["cfg_scale"] = arguments["cfg_scale"]
 
+    # Pass through any model-specific parameters
+    if "extra_params" in arguments:
+        fal_args.update(arguments["extra_params"])
+
     logger.info("Submitting async video generation with %s", model_id)
     try:
         handle = await fal_client.submit_async(model_id, arguments=fal_args)

--- a/src/fal_mcp_server/handlers/video_handlers.py
+++ b/src/fal_mcp_server/handlers/video_handlers.py
@@ -400,14 +400,9 @@ async def handle_submit_video(
             )
         ]
 
-    fal_args: Dict[str, Any] = {}
-
-    # multi_prompt overrides single prompt (for multi-shot models like Kling v3)
-    if "multi_prompt" in arguments:
-        fal_args["multi_prompt"] = arguments["multi_prompt"]
-    else:
-        fal_args["prompt"] = arguments["prompt"]
-
+    fal_args: Dict[str, Any] = {
+        "prompt": arguments["prompt"],
+    }
     if "image_url" in arguments:
         fal_args["image_url"] = arguments["image_url"]
     if "duration" in arguments:

--- a/src/fal_mcp_server/handlers/video_handlers.py
+++ b/src/fal_mcp_server/handlers/video_handlers.py
@@ -1,12 +1,14 @@
 """
 Video handler implementations for Fal.ai MCP Server.
 
-Contains: generate_video, generate_video_from_image, generate_video_from_video
+Contains: generate_video, generate_video_from_image, generate_video_from_video,
+          submit_video, check_video_status
 """
 
 import asyncio
 from typing import Any, Dict, List
 
+import fal_client
 from loguru import logger
 from mcp.types import TextContent
 
@@ -374,5 +376,160 @@ async def handle_generate_video_from_video(
         TextContent(
             type="text",
             text="❌ Video transformation completed but no video URL was returned. Please try again.",
+        )
+    ]
+
+
+async def handle_submit_video(
+    arguments: Dict[str, Any],
+    registry: ModelRegistry,
+) -> List[TextContent]:
+    """Submit a video generation job and return immediately with a request ID.
+
+    Use check_video_status to poll for the result. This is useful for
+    long-running models (e.g. Kling Pro) that exceed the default timeout.
+    """
+    model_input = arguments.get("model", "fal-ai/wan-i2v")
+    try:
+        model_id = await registry.resolve_model_id(model_input)
+    except ValueError as e:
+        return [
+            TextContent(
+                type="text",
+                text=f"❌ {e}. Use list_models to see available options.",
+            )
+        ]
+
+    fal_args: Dict[str, Any] = {
+        "prompt": arguments["prompt"],
+    }
+    if "image_url" in arguments:
+        fal_args["image_url"] = arguments["image_url"]
+    if "duration" in arguments:
+        fal_args["duration"] = arguments["duration"]
+    if "aspect_ratio" in arguments:
+        fal_args["aspect_ratio"] = arguments["aspect_ratio"]
+    if "negative_prompt" in arguments:
+        fal_args["negative_prompt"] = arguments["negative_prompt"]
+    if "cfg_scale" in arguments:
+        fal_args["cfg_scale"] = arguments["cfg_scale"]
+
+    logger.info("Submitting async video generation with %s", model_id)
+    try:
+        handle = await fal_client.submit_async(model_id, arguments=fal_args)
+    except Exception as e:
+        logger.exception("Failed to submit video job to %s", model_id)
+        return [
+            TextContent(
+                type="text",
+                text=f"❌ Failed to submit video job: {e}",
+            )
+        ]
+
+    return [
+        TextContent(
+            type="text",
+            text=(
+                f"✅ Video job submitted to {model_id}\n\n"
+                f"**request_id**: `{handle.request_id}`\n"
+                f"**model**: `{model_id}`\n\n"
+                f"Use `check_video_status` with the request_id and model above to check progress and retrieve the result."
+            ),
+        )
+    ]
+
+
+async def handle_check_video_status(
+    arguments: Dict[str, Any],
+    registry: ModelRegistry,
+) -> List[TextContent]:
+    """Check the status of a submitted video job and return the result if complete."""
+    request_id = arguments["request_id"]
+    model_id = arguments["model"]
+
+    logger.info("Checking video status for %s on %s", request_id, model_id)
+    try:
+        status = await fal_client.status_async(
+            model_id, request_id, with_logs=True
+        )
+    except Exception as e:
+        logger.exception(
+            "Failed to check status for %s on %s", request_id, model_id
+        )
+        return [
+            TextContent(
+                type="text",
+                text=f"❌ Failed to check status: {e}",
+            )
+        ]
+
+    if isinstance(status, fal_client.Queued):
+        return [
+            TextContent(
+                type="text",
+                text=f"⏳ Queued — position {status.position}. Call check_video_status again later.",
+            )
+        ]
+
+    if isinstance(status, fal_client.InProgress):
+        log_lines = ""
+        if status.logs:
+            log_lines = "\n".join(
+                entry.get("message", "") for entry in status.logs[-5:]
+            )
+        return [
+            TextContent(
+                type="text",
+                text=f"🔄 In progress…{chr(10) + log_lines if log_lines else ''}\n\nCall check_video_status again later.",
+            )
+        ]
+
+    if isinstance(status, fal_client.Completed):
+        # Fetch the actual result
+        try:
+            result = await fal_client.result_async(model_id, request_id)
+            video_result = dict(result) if result else {}
+        except Exception as e:
+            return [
+                TextContent(
+                    type="text",
+                    text=f"❌ Job completed but failed to fetch result: {e}",
+                )
+            ]
+
+        if "error" in video_result:
+            return [
+                TextContent(
+                    type="text",
+                    text=f"❌ Video generation failed: {video_result['error']}",
+                )
+            ]
+
+        video_dict = video_result.get("video", {})
+        if isinstance(video_dict, dict):
+            video_url = video_dict.get("url")
+        else:
+            video_url = video_result.get("url")
+
+        if video_url:
+            return [
+                TextContent(
+                    type="text",
+                    text=f"🎬 Video ready: {video_url}",
+                )
+            ]
+
+        return [
+            TextContent(
+                type="text",
+                text="❌ Job completed but no video URL in response.",
+            )
+        ]
+
+    # Unknown status
+    return [
+        TextContent(
+            type="text",
+            text=f"❓ Unknown status: {status}",
         )
     ]

--- a/src/fal_mcp_server/handlers/video_handlers.py
+++ b/src/fal_mcp_server/handlers/video_handlers.py
@@ -400,9 +400,14 @@ async def handle_submit_video(
             )
         ]
 
-    fal_args: Dict[str, Any] = {
-        "prompt": arguments["prompt"],
-    }
+    fal_args: Dict[str, Any] = {}
+
+    # multi_prompt overrides single prompt (for multi-shot models like Kling v3)
+    if "multi_prompt" in arguments:
+        fal_args["multi_prompt"] = arguments["multi_prompt"]
+    else:
+        fal_args["prompt"] = arguments["prompt"]
+
     if "image_url" in arguments:
         fal_args["image_url"] = arguments["image_url"]
     if "duration" in arguments:

--- a/src/fal_mcp_server/server.py
+++ b/src/fal_mcp_server/server.py
@@ -18,6 +18,7 @@ from mcp.types import ServerCapabilities, TextContent, Tool, ToolsCapability
 
 # Handlers (transport-agnostic business logic)
 from fal_mcp_server.handlers import (
+    handle_check_video_status,
     handle_compose_images,
     handle_edit_image,
     handle_generate_image,
@@ -34,6 +35,7 @@ from fal_mcp_server.handlers import (
     handle_recommend_model,
     handle_remove_background,
     handle_resize_image,
+    handle_submit_video,
     handle_upload_file,
     handle_upscale_image,
 )
@@ -80,6 +82,8 @@ TOOL_HANDLERS = {
     "generate_video": handle_generate_video,
     "generate_video_from_image": handle_generate_video_from_image,
     "generate_video_from_video": handle_generate_video_from_video,
+    "submit_video": handle_submit_video,
+    "check_video_status": handle_check_video_status,
     # Audio tools
     "generate_music": handle_generate_music,
 }
@@ -91,6 +95,8 @@ NO_QUEUE_TOOLS = {
     "get_pricing",
     "get_usage",
     "upload_file",
+    "submit_video",
+    "check_video_status",
 }
 
 

--- a/src/fal_mcp_server/tools/video_tools.py
+++ b/src/fal_mcp_server/tools/video_tools.py
@@ -179,13 +179,34 @@ VIDEO_TOOLS: List[Tool] = [
     ),
     Tool(
         name="submit_video",
-        description="Submit a video generation job and return immediately with a request ID. Unlike generate_video, this does NOT wait for the result — use check_video_status to poll. Ideal for long-running models (e.g. Kling Pro, high-duration videos) that may exceed timeout limits.",
+        description="Submit a video generation job and return immediately with a request ID. Unlike generate_video, this does NOT wait for the result — use check_video_status to poll. Ideal for long-running models (e.g. Kling Pro, high-duration videos) that may exceed timeout limits. Supports multi-shot via multi_prompt.",
         inputSchema={
             "type": "object",
             "properties": {
                 "prompt": {
                     "type": "string",
-                    "description": "Text description for the video",
+                    "description": "Text description for the video. Use this OR multi_prompt, not both.",
+                },
+                "multi_prompt": {
+                    "type": "array",
+                    "description": "Multi-shot prompts for models that support it (e.g. Kling v3). Each item is a shot with its own prompt and duration. Overrides the single prompt field.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "prompt": {
+                                "type": "string",
+                                "description": "The prompt for this shot",
+                            },
+                            "duration": {
+                                "type": "integer",
+                                "minimum": 3,
+                                "maximum": 15,
+                                "default": 5,
+                                "description": "Duration of this shot in seconds (3-15)",
+                            },
+                        },
+                        "required": ["prompt"],
+                    },
                 },
                 "image_url": {
                     "type": "string",
@@ -201,7 +222,7 @@ VIDEO_TOOLS: List[Tool] = [
                     "default": 5,
                     "minimum": 2,
                     "maximum": 10,
-                    "description": "Video duration in seconds",
+                    "description": "Overall video duration in seconds (ignored when multi_prompt is used)",
                 },
                 "aspect_ratio": {
                     "type": "string",
@@ -218,7 +239,10 @@ VIDEO_TOOLS: List[Tool] = [
                     "description": "Classifier-free guidance scale (0.0-1.0). Lower values give more creative results.",
                 },
             },
-            "required": ["prompt"],
+            "oneOf": [
+                {"required": ["prompt"]},
+                {"required": ["multi_prompt"]},
+            ],
         },
     ),
     Tool(

--- a/src/fal_mcp_server/tools/video_tools.py
+++ b/src/fal_mcp_server/tools/video_tools.py
@@ -185,28 +185,7 @@ VIDEO_TOOLS: List[Tool] = [
             "properties": {
                 "prompt": {
                     "type": "string",
-                    "description": "Text description for the video. Use this OR multi_prompt, not both.",
-                },
-                "multi_prompt": {
-                    "type": "array",
-                    "description": "Multi-shot prompts for models that support it (e.g. Kling v3). Each item is a shot with its own prompt and duration. Overrides the single prompt field.",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "prompt": {
-                                "type": "string",
-                                "description": "The prompt for this shot",
-                            },
-                            "duration": {
-                                "type": "integer",
-                                "minimum": 3,
-                                "maximum": 15,
-                                "default": 5,
-                                "description": "Duration of this shot in seconds (3-15)",
-                            },
-                        },
-                        "required": ["prompt"],
-                    },
+                    "description": "Text description for the video",
                 },
                 "image_url": {
                     "type": "string",
@@ -243,10 +222,7 @@ VIDEO_TOOLS: List[Tool] = [
                     "description": "Model-specific parameters passed directly to the fal.ai API (e.g. {\"generate_audio\": true, \"shot_type\": \"customize\", \"voice_ids\": [\"id1\"]} for Kling v3).",
                 },
             },
-            "oneOf": [
-                {"required": ["prompt"]},
-                {"required": ["multi_prompt"]},
-            ],
+            "required": ["prompt"],
         },
     ),
     Tool(

--- a/src/fal_mcp_server/tools/video_tools.py
+++ b/src/fal_mcp_server/tools/video_tools.py
@@ -1,7 +1,8 @@
 """
 Video tool definitions for Fal.ai MCP Server.
 
-Contains: generate_video, generate_video_from_image, generate_video_from_video
+Contains: generate_video, generate_video_from_image, generate_video_from_video,
+          submit_video, check_video_status
 """
 
 from typing import List
@@ -174,6 +175,68 @@ VIDEO_TOOLS: List[Tool] = [
                 },
             },
             "required": ["video_url", "prompt"],
+        },
+    ),
+    Tool(
+        name="submit_video",
+        description="Submit a video generation job and return immediately with a request ID. Unlike generate_video, this does NOT wait for the result — use check_video_status to poll. Ideal for long-running models (e.g. Kling Pro, high-duration videos) that may exceed timeout limits.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "Text description for the video",
+                },
+                "image_url": {
+                    "type": "string",
+                    "description": "Starting image URL for image-to-video models. Optional for text-to-video models.",
+                },
+                "model": {
+                    "type": "string",
+                    "default": "fal-ai/wan-i2v",
+                    "description": "Model ID (e.g. 'fal-ai/kling-video/v3/pro/text-to-video'). Use list_models to discover available models.",
+                },
+                "duration": {
+                    "type": "integer",
+                    "default": 5,
+                    "minimum": 2,
+                    "maximum": 10,
+                    "description": "Video duration in seconds",
+                },
+                "aspect_ratio": {
+                    "type": "string",
+                    "default": "16:9",
+                    "description": "Video aspect ratio (e.g., '16:9', '9:16', '1:1')",
+                },
+                "negative_prompt": {
+                    "type": "string",
+                    "description": "What to avoid in the video (e.g., 'blur, distort, low quality')",
+                },
+                "cfg_scale": {
+                    "type": "number",
+                    "default": 0.5,
+                    "description": "Classifier-free guidance scale (0.0-1.0). Lower values give more creative results.",
+                },
+            },
+            "required": ["prompt"],
+        },
+    ),
+    Tool(
+        name="check_video_status",
+        description="Check the status of a video job submitted via submit_video. Returns queue position if waiting, progress if running, or the video URL if complete.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "request_id": {
+                    "type": "string",
+                    "description": "The request_id returned by submit_video",
+                },
+                "model": {
+                    "type": "string",
+                    "description": "The model ID used when submitting (returned by submit_video)",
+                },
+            },
+            "required": ["request_id", "model"],
         },
     ),
 ]

--- a/src/fal_mcp_server/tools/video_tools.py
+++ b/src/fal_mcp_server/tools/video_tools.py
@@ -238,6 +238,10 @@ VIDEO_TOOLS: List[Tool] = [
                     "default": 0.5,
                     "description": "Classifier-free guidance scale (0.0-1.0). Lower values give more creative results.",
                 },
+                "extra_params": {
+                    "type": "object",
+                    "description": "Model-specific parameters passed directly to the fal.ai API (e.g. {\"generate_audio\": true, \"shot_type\": \"customize\", \"voice_ids\": [\"id1\"]} for Kling v3).",
+                },
             },
             "oneOf": [
                 {"required": ["prompt"]},


### PR DESCRIPTION
## Summary

Adds two new tools for non-blocking video generation:

- **`submit_video`**: submits a job via `fal_client.submit_async()` and returns the `request_id` immediately
- **`check_video_status`**: polls status via `fal_client.status_async()` and fetches the result when complete

## Problem

Long-running video models (Kling Pro, high-duration generations) regularly exceed the hardcoded 180s timeout in `generate_video`, causing timeout errors even though the job is still processing on fal.ai's queue.

## Solution

Instead of increasing the timeout, this introduces a fire-and-forget pattern:

1. `submit_video` → submits job, returns `request_id` + `model` instantly
2. `check_video_status(request_id, model)` → returns:
   - `⏳ Queued` with queue position
   - `🔄 In progress` with recent log lines
   - `🎬 Video ready` with the final URL

### Generic extra_params

Model-specific parameters can be passed via `extra_params` without requiring tool definition updates per model. For example, Kling v3 multi-shot with audio:

```json
{
  "prompt": "A cinematic scene",
  "model": "fal-ai/kling-video/v3/pro/text-to-video",
  "aspect_ratio": "9:16",
  "extra_params": {
    "multi_prompt": [
      {"prompt": "Scene 1 description", "duration": 5},
      {"prompt": "Scene 2 description", "duration": 5}
    ],
    "generate_audio": true,
    "shot_type": "customize"
  }
}
```

Existing synchronous tools (`generate_video`, `generate_video_from_image`, `generate_video_from_video`) are **unchanged**.

## Test plan

- [x] All 103 existing tests pass
- [x] Mock test: `submit_video` returns request_id
- [x] Mock test: `check_video_status` handles Queued → InProgress → Completed
- [x] Mock test: `extra_params` merged into API call (multi_prompt, generate_audio, etc.)
- [x] Error handling: API errors returned cleanly