### PR TITLE
feat: Support tail_image_url in generate_video_from_image for Kling FLF

### DIFF
--- a/src/fal_mcp_server/handlers/video_handlers.py
+++ b/src/fal_mcp_server/handlers/video_handlers.py
@@ -132,6 +132,9 @@ async def handle_generate_video_from_image(
         fal_args["negative_prompt"] = arguments["negative_prompt"]
     if "cfg_scale" in arguments:
         fal_args["cfg_scale"] = arguments["cfg_scale"]
+    # Kling first-last-frame transition support (v3/4k, o3, v1.6 pro, v2.x pro)
+    if "tail_image_url" in arguments:
+        fal_args["tail_image_url"] = arguments["tail_image_url"]
 
     # Use queue strategy with timeout protection
     logger.info(

--- a/src/fal_mcp_server/tools/video_tools.py
+++ b/src/fal_mcp_server/tools/video_tools.py
@@ -55,7 +55,7 @@ VIDEO_TOOLS: List[Tool] = [
     ),
     Tool(
         name="generate_video_from_image",
-        description="Animate an image into a video. The image serves as the starting frame and the prompt guides the animation. Use upload_file first if you have a local image.",
+        description="Animate an image into a video. The image serves as the starting frame and the prompt guides the animation. Optionally provide tail_image_url to interpolate to an end frame (Kling first-last-frame transition models). Use upload_file first if you have a local image.",
         inputSchema={
             "type": "object",
             "properties": {
@@ -70,7 +70,7 @@ VIDEO_TOOLS: List[Tool] = [
                 "model": {
                     "type": "string",
                     "default": "fal-ai/wan-i2v",
-                    "description": "Image-to-video model. Options: fal-ai/wan-i2v, fal-ai/kling-video/v2.1/standard/image-to-video",
+                    "description": "Image-to-video model. Options: fal-ai/wan-i2v, fal-ai/kling-video/v2.1/standard/image-to-video. For first-last-frame transitions, use a Kling model that supports it (e.g., fal-ai/kling-video/v3/4k/image-to-video, fal-ai/kling-video/o3/standard/image-to-video) and pass tail_image_url.",
                 },
                 "duration": {
                     "type": "integer",
@@ -92,6 +92,10 @@ VIDEO_TOOLS: List[Tool] = [
                     "type": "number",
                     "default": 0.5,
                     "description": "Classifier-free guidance scale (0.0-1.0). Lower values give more creative results.",
+                },
+                "tail_image_url": {
+                    "type": "string",
+                    "description": "[Kling first-last-frame] URL of the image for the END frame. When set with a compatible Kling model (v3/4k, o3, v1.6 pro, v2.x pro), generates a smooth transition from image_url to tail_image_url.",
                 },
             },
             "required": ["image_url", "prompt"],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -288,6 +288,11 @@ async def test_generate_video_from_image_tool_schema():
     assert "negative_prompt" in props
     assert "cfg_scale" in props
 
+    # Kling first-last-frame transition support
+    assert "tail_image_url" in props
+    assert props["tail_image_url"]["type"] == "string"
+    assert "tail_image_url" not in video_tool.inputSchema["required"]
+
     # Both image_url and prompt are required for image-to-video
     assert "image_url" in video_tool.inputSchema["required"]
     assert "prompt" in video_tool.inputSchema["required"]


### PR DESCRIPTION
## Summary

Adds optional `tail_image_url` parameter to the `generate_video_from_image` tool, enabling first-last-frame (FLF) transition videos with Kling models that support keyframe interpolation on fal.ai (v3/4k, o3/standard, v1.6/pro, v2.x/pro, etc.).

Previously the parameter existed only in `generate_video_from_video` (which requires a source video). MCP clients had no way to generate keyframe-to-keyframe videos from two still images, even though fal.ai's API supports it natively for these Kling models.

## Why

Several Kling endpoints on fal.ai accept both `image_url` (start frame) and `tail_image_url` (end frame) on their `/image-to-video` endpoints, producing a smooth interpolation between the two — the canonical "first frame to last frame" workflow:

- `fal-ai/kling-video/v3/4k/image-to-video`
- `fal-ai/kling-video/o3/standard/image-to-video`
- `fal-ai/kling-video/v3/pro/image-to-video`
- `fal-ai/kling-video/v1.6/pro/image-to-video`
- `fal-ai/kling-video/v2.6/pro/image-to-video`

Without this PR, MCP clients have to drop down to `fal-client` directly to use the feature, defeating the purpose of having a unified MCP wrapper.

## Changes

| File | Change |
|---|---|
| `src/fal_mcp_server/tools/video_tools.py` | Add optional `tail_image_url` to `generate_video_from_image` schema; expand the `model` description to mention FLF-capable Kling endpoints. |
| `src/fal_mcp_server/handlers/video_handlers.py` | Forward `tail_image_url` to `fal_args` when present. |
| `tests/test_server.py` | Assert the new schema field is exposed and remains optional. |

## Tests

```bash
pytest tests/test_server.py -k "generate_video_from_image_tool_schema or list_tools" -v
# 2 passed, 15 deselected
```

End-to-end smoke test against `fal-ai/kling-video/o3/standard/image-to-video` with two real product photos: 5s 828×1108 H.264 video generated, smooth interpolation between start and end frames as expected. Cost: $0.70.

## Backward compatibility

`tail_image_url` is optional and defaults to absent. Existing calls that pass only `image_url` behave identically. No breaking changes.

## Related

Issue #113 (`get_usage` bug with `expand=summary`) is unrelated and not addressed by this PR.
