### PR TITLE
Fix image_size for openai/gpt-image-2 and add aspect/width/height params

### DIFF
--- a/src/fal_mcp_server/handlers/image_handlers.py
+++ b/src/fal_mcp_server/handlers/image_handlers.py
@@ -14,6 +14,54 @@ from mcp.types import TextContent
 from fal_mcp_server.model_registry import ModelRegistry
 from fal_mcp_server.queue.base import QueueStrategy
 
+# Models that require {"width": N, "height": N} instead of a string alias
+_PIXEL_SIZE_MODELS = {
+    "openai/gpt-image-2",
+    "openai/gpt-image-2/edit",
+    "fal-ai/gpt-image-1.5",
+    "fal-ai/gpt-image-1.5/edit",
+}
+
+# Standard string aliases mapped to (w_ratio, h_ratio)
+_ALIAS_RATIOS: Dict[str, tuple] = {
+    "square":         (1, 1),
+    "square_hd":      (1, 1),
+    "landscape_4_3":  (4, 3),
+    "landscape_16_9": (16, 9),
+    "portrait_3_4":   (3, 4),
+    "portrait_9_16":  (9, 16),
+}
+
+
+def _compute_pixel_size(w_ratio: int, h_ratio: int, long_side: int) -> Dict[str, int]:
+    """Return {width, height} from aspect ratio and long-side pixels."""
+    if w_ratio >= h_ratio:
+        return {"width": long_side, "height": round(long_side * h_ratio / w_ratio)}
+    return {"width": round(long_side * w_ratio / h_ratio), "height": long_side}
+
+
+def _resolve_image_size(model_id: str, arguments: Dict[str, Any]) -> Any:
+    """Resolve image size from arguments with priority:
+    1. width + height  → pixel object (always)
+    2. aspect + size_px → compute pixel object from ratio (size_px = long side)
+    3. image_size alias → pixel object for pixel-only models, string otherwise
+    """
+    if "width" in arguments and "height" in arguments:
+        return {"width": arguments["width"], "height": arguments["height"]}
+
+    if "aspect" in arguments:
+        w_ratio, h_ratio = map(int, arguments["aspect"].split(":"))
+        return _compute_pixel_size(w_ratio, h_ratio, arguments.get("size_px", 1024))
+
+    alias = arguments.get("image_size", "landscape_16_9")
+    needs_pixels = any(
+        model_id == m or model_id.startswith(m + "/") for m in _PIXEL_SIZE_MODELS
+    )
+    if needs_pixels:
+        ratios = _ALIAS_RATIOS.get(alias, (4, 3))
+        return _compute_pixel_size(ratios[0], ratios[1], 1024)
+    return alias
+
 
 async def handle_generate_image(
     arguments: Dict[str, Any],
@@ -34,7 +82,7 @@ async def handle_generate_image(
 
     fal_args: Dict[str, Any] = {
         "prompt": arguments["prompt"],
-        "image_size": arguments.get("image_size", "landscape_16_9"),
+        "image_size": _resolve_image_size(model_id, arguments),
         "num_images": arguments.get("num_images", 1),
     }
 
@@ -142,7 +190,7 @@ async def handle_generate_image_structured(
 
     fal_args: Dict[str, Any] = {
         "prompt": json_prompt,
-        "image_size": arguments.get("image_size", "landscape_16_9"),
+        "image_size": _resolve_image_size(model_id, arguments),
         "num_images": arguments.get("num_images", 1),
     }
 

--- a/src/fal_mcp_server/tools/image_tools.py
+++ b/src/fal_mcp_server/tools/image_tools.py
@@ -32,12 +32,31 @@ IMAGE_TOOLS: List[Tool] = [
                     "type": "string",
                     "enum": [
                         "square",
+                        "square_hd",
                         "landscape_4_3",
                         "landscape_16_9",
                         "portrait_3_4",
                         "portrait_9_16",
                     ],
                     "default": "landscape_16_9",
+                    "description": "Size alias (works for most models). For GPT-Image-2 and other OpenAI models, alias is auto-converted to pixels.",
+                },
+                "aspect": {
+                    "type": "string",
+                    "description": "Aspect ratio as 'W:H' (e.g. '3:4', '16:9', '1:1', '9:16'). Use with size_px. Overrides image_size.",
+                },
+                "size_px": {
+                    "type": "integer",
+                    "default": 1024,
+                    "description": "Long side in pixels. Used with aspect to compute exact dimensions.",
+                },
+                "width": {
+                    "type": "integer",
+                    "description": "Exact width in pixels. Use with height for full pixel control. Highest priority.",
+                },
+                "height": {
+                    "type": "integer",
+                    "description": "Exact height in pixels. Use with width for full pixel control. Highest priority.",
                 },
                 "num_images": {
                     "type": "integer",
@@ -173,12 +192,31 @@ IMAGE_TOOLS: List[Tool] = [
                     "type": "string",
                     "enum": [
                         "square",
+                        "square_hd",
                         "landscape_4_3",
                         "landscape_16_9",
                         "portrait_3_4",
                         "portrait_9_16",
                     ],
                     "default": "landscape_16_9",
+                    "description": "Size alias (works for most models). For GPT-Image-2 and other OpenAI models, alias is auto-converted to pixels.",
+                },
+                "aspect": {
+                    "type": "string",
+                    "description": "Aspect ratio as 'W:H' (e.g. '3:4', '16:9', '1:1', '9:16'). Use with size_px. Overrides image_size.",
+                },
+                "size_px": {
+                    "type": "integer",
+                    "default": 1024,
+                    "description": "Long side in pixels. Used with aspect to compute exact dimensions.",
+                },
+                "width": {
+                    "type": "integer",
+                    "description": "Exact width in pixels. Use with height for full pixel control. Highest priority.",
+                },
+                "height": {
+                    "type": "integer",
+                    "description": "Exact height in pixels. Use with width for full pixel control. Highest priority.",
                 },
                 "num_images": {
                     "type": "integer",


### PR DESCRIPTION
Closes #120

## Problem

`generate_image` and `generate_image_structured` fail with a Pydantic validation error when called against `openai/gpt-image-2` (and other OpenAI-based fal endpoints):

```
{"type": "model_attributes_type", "loc": ["body", "image_size", "ImageSize"],
 "msg": "Input should be a valid dictionary or object to extract fields from",
 "input": "portrait_3_4"}
```

These endpoints require `image_size` as an object `{"width": N, "height": N}`. The existing handlers pass the string alias straight through, so any user hitting these models from MCP gets a hard failure even though the alias is in the schema's `enum`.

## Fix

Three layered improvements, all backward-compatible:

### 1. Auto-conversion for pixel-only models (the main fix)

A new `_resolve_image_size()` helper detects pixel-only models and converts the standard string alias into a pixel object transparently:

```python
_PIXEL_SIZE_MODELS = {
    "openai/gpt-image-2",
    "openai/gpt-image-2/edit",
    "fal-ai/gpt-image-1.5",
    "fal-ai/gpt-image-1.5/edit",
}
```

Result: `generate_image(model="openai/gpt-image-2", image_size="portrait_3_4")` now works — alias is converted to `{"width": 768, "height": 1024}` before being sent to fal. Other models (Flux, SDXL, etc.) keep receiving the string alias unchanged.

### 2. New `aspect` + `size_px` parameters

For arbitrary aspect ratios without hardcoded resolutions:

```python
generate_image(
    model="openai/gpt-image-2",
    aspect="3:4",      # any "W:H" ratio, including non-standard ones like "7:9"
    size_px=1024       # long side in pixels
)
# → image_size = {"width": 768, "height": 1024}
```

The handler computes width/height from the ratio — no hardcoded size table. Works for any model.

### 3. New explicit `width` + `height` parameters

For maximum control:

```python
generate_image(model="openai/gpt-image-2", width=512, height=683)
```

### Resolution priority

```
width + height  >  aspect + size_px  >  image_size (alias)
```

### Other small changes

- Added `square_hd` to the `image_size` enum (it was already accepted by Flux/SDXL but missing from the schema).
- Added a description to the existing `image_size` field clarifying the auto-conversion behavior for OpenAI models.

## Backward compatibility

All existing calls work unchanged:

- `image_size="portrait_3_4"` against Flux/SDXL → string alias passed through (no change)
- `image_size="portrait_3_4"` against `openai/gpt-image-2` → previously **failed**, now succeeds with `{"width": 768, "height": 1024}`
- No required parameters added.

## Test plan

Verified locally with all six paths:

- [x] Flux + string alias → string passed through
- [x] GPT-Image 2 + string alias → auto-converted to pixel object
- [x] GPT-Image 2 + `aspect`/`size_px` → computed object
- [x] GPT-Image 2 + explicit `width`/`height` → object as-is
- [x] Custom non-standard aspect (`7:9`, `size_px=900`) → `{"width": 700, "height": 900}`
- [x] Flux + `aspect`/`size_px` → object (works because Flux accepts both forms)

## Notes

I noticed that the repo's `.mcp.json` ships a development MCP configuration including `playwright`, `memory`, `allpepper-memory-bank`, `sequential-thinking`, and `fal-ai-docker` (a localhost SSE endpoint). When users clone the repo or install the marketplace plugin, these get registered as project-level MCP servers and produce errors (e.g. `CLAUDE_PROJECT_DIR` unbound). This seems like a separate cleanup unrelated to this PR — happy to file a separate issue if helpful.