### PR TITLE
fix: convert image_size aliases to pixel objects for OpenAI models

### DIFF
--- a/src/fal_mcp_server/handlers/image_handlers.py
+++ b/src/fal_mcp_server/handlers/image_handlers.py
@@ -6,13 +6,40 @@ Contains: generate_image, generate_image_structured, generate_image_from_image
 
 import asyncio
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from loguru import logger
 from mcp.types import TextContent
 
 from fal_mcp_server.model_registry import ModelRegistry
 from fal_mcp_server.queue.base import QueueStrategy
+
+IMAGE_SIZE_TO_PIXELS: Dict[str, Dict[str, int]] = {
+    "square": {"width": 1024, "height": 1024},
+    "landscape_4_3": {"width": 1024, "height": 768},
+    "landscape_16_9": {"width": 1024, "height": 576},
+    "portrait_3_4": {"width": 768, "height": 1024},
+    "portrait_9_16": {"width": 576, "height": 1024},
+}
+
+PIXEL_ONLY_MODEL_PATTERNS = ("openai/", "gpt-image")
+
+
+def _requires_pixel_size(model_id: str) -> bool:
+    """Check if a model requires pixel-based image_size instead of string aliases."""
+    model_lower = model_id.lower()
+    return any(pattern in model_lower for pattern in PIXEL_ONLY_MODEL_PATTERNS)
+
+
+def resolve_image_size(
+    image_size: str, model_id: str
+) -> Union[str, Dict[str, int]]:
+    """Convert image_size string alias to pixel dict for models that require it."""
+    if not _requires_pixel_size(model_id):
+        return image_size
+    if image_size in IMAGE_SIZE_TO_PIXELS:
+        return IMAGE_SIZE_TO_PIXELS[image_size]
+    return image_size
 
 
 async def handle_generate_image(
@@ -32,9 +59,13 @@ async def handle_generate_image(
             )
         ]
 
+    image_size = resolve_image_size(
+        arguments.get("image_size", "landscape_16_9"), model_id
+    )
+
     fal_args: Dict[str, Any] = {
         "prompt": arguments["prompt"],
-        "image_size": arguments.get("image_size", "landscape_16_9"),
+        "image_size": image_size,
         "num_images": arguments.get("num_images", 1),
     }
 
@@ -140,9 +171,13 @@ async def handle_generate_image_structured(
     # Convert structured prompt to JSON string
     json_prompt = json.dumps(structured_prompt, indent=2)
 
+    image_size = resolve_image_size(
+        arguments.get("image_size", "landscape_16_9"), model_id
+    )
+
     fal_args: Dict[str, Any] = {
         "prompt": json_prompt,
-        "image_size": arguments.get("image_size", "landscape_16_9"),
+        "image_size": image_size,
         "num_images": arguments.get("num_images", 1),
     }
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -473,6 +473,48 @@ def test_fal_model_default_values():
     assert model.thumbnail_url is None
 
 
+def test_resolve_image_size_passthrough_for_standard_models():
+    """Test that string aliases pass through unchanged for standard fal models."""
+    from fal_mcp_server.handlers.image_handlers import resolve_image_size
+
+    assert resolve_image_size("portrait_3_4", "fal-ai/flux/schnell") == "portrait_3_4"
+    assert resolve_image_size("landscape_16_9", "fal-ai/fast-sdxl") == "landscape_16_9"
+    assert resolve_image_size("square", "fal-ai/flux-pro") == "square"
+
+
+def test_resolve_image_size_converts_for_openai_models():
+    """Test that string aliases are converted to pixel dicts for OpenAI-based models."""
+    from fal_mcp_server.handlers.image_handlers import resolve_image_size
+
+    result = resolve_image_size("portrait_3_4", "openai/gpt-image-2")
+    assert result == {"width": 768, "height": 1024}
+
+    result = resolve_image_size("landscape_16_9", "openai/gpt-image-2")
+    assert result == {"width": 1024, "height": 576}
+
+    result = resolve_image_size("square", "openai/gpt-image-2/edit")
+    assert result == {"width": 1024, "height": 1024}
+
+
+def test_resolve_image_size_converts_for_gpt_image_models():
+    """Test that fal-hosted GPT image models also get pixel conversion."""
+    from fal_mcp_server.handlers.image_handlers import resolve_image_size
+
+    result = resolve_image_size("portrait_9_16", "fal-ai/gpt-image-1.5")
+    assert result == {"width": 576, "height": 1024}
+
+    result = resolve_image_size("landscape_4_3", "fal-ai/gpt-image-1.5/edit")
+    assert result == {"width": 1024, "height": 768}
+
+
+def test_resolve_image_size_unknown_alias_passes_through():
+    """Test that unrecognized size strings pass through even for pixel-based models."""
+    from fal_mcp_server.handlers.image_handlers import resolve_image_size
+
+    result = resolve_image_size("custom_size", "openai/gpt-image-2")
+    assert result == "custom_size"
+
+
 if __name__ == "__main__":
     tests_passed = 0
     tests_failed = 0


### PR DESCRIPTION
## Summary

Fixes #120 — `generate_image` and `generate_image_structured` fail with a Pydantic validation error when using OpenAI-based models (`openai/gpt-image-2`, `fal-ai/gpt-image-1.5`, etc.) because they require `image_size` as `{"width": N, "height": N}` instead of string aliases like `"portrait_3_4"`.

**Changes:**
- Added `resolve_image_size()` that transparently converts string aliases to pixel dicts when the target model requires it
- Detection uses substring matching (`"openai/"`, `"gpt-image"`) so future OpenAI models work without code changes
- Standard fal models are unaffected — string aliases pass through unchanged
- Added 4 unit tests covering all paths (passthrough, conversion, unknown alias fallback)

## Test plan

- [x] All 21 existing tests pass
- [x] 4 new tests for `resolve_image_size` pass
- [x] `ruff check` clean
- [x] `mypy` clean
- [ ] Manual: `generate_image(model="openai/gpt-image-2", prompt="a cat", image_size="portrait_3_4")` should succeed instead of returning validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)